### PR TITLE
[FEAT] Geolocation duplication validation and improved feedback for Ubicaciones

### DIFF
--- a/src/main/kotlin/com/crisordonez/registro/controller/UbicacionController.kt
+++ b/src/main/kotlin/com/crisordonez/registro/controller/UbicacionController.kt
@@ -7,6 +7,7 @@ import com.crisordonez.registro.service.UbicacionServiceInterface
 import com.crisordonez.registro.model.mapper.UbicacionMapper
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.util.*
 
@@ -29,17 +30,24 @@ class UbicacionController(
     }
 
     @PostMapping
-    fun crearUbicacion(@RequestBody ubicacionRequest: UbicacionRequest): UbicacionResponse {
-        val entity = ubicacionService.crearUbicacion(UbicacionMapper.toEntity(ubicacionRequest))
-        return UbicacionMapper.toResponse(entity)
+    fun crearUbicacion(@RequestBody ubicacionRequest: UbicacionRequest): ResponseEntity<*> {
+        return try {
+            val entity = ubicacionService.crearUbicacion(UbicacionMapper.toEntity(ubicacionRequest))
+            ResponseEntity.ok(UbicacionMapper.toResponse(entity))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("mensaje" to e.message))
+        }
     }
 
     @PostMapping("/lote")
-    fun crearUbicaciones(@RequestBody ubicacionesRequest: List<UbicacionRequest>): List<UbicacionResponse> {
-        val entidades = ubicacionService.crearUbicaciones(
-            ubicacionesRequest.map { UbicacionMapper.toEntity(it) }
+    fun crearUbicaciones(@RequestBody ubicacionesRequest: List<UbicacionRequest>): Map<String, Any> {
+        val entidades = ubicacionesRequest.map { UbicacionMapper.toEntity(it) }
+        val resultado = ubicacionService.crearUbicaciones(entidades)
+
+        return mapOf(
+            "creadas" to UbicacionMapper.toResponseList(resultado.creadas),
+            "rechazadas" to resultado.rechazadas
         )
-        return UbicacionMapper.toResponseList(entidades)
     }
 
     @PutMapping("/{publicId}")

--- a/src/main/kotlin/com/crisordonez/registro/model/responses/UbicacionResponse.kt
+++ b/src/main/kotlin/com/crisordonez/registro/model/responses/UbicacionResponse.kt
@@ -13,3 +13,9 @@ data class UbicacionResponse(
     val longitud: Double,
     val establecimiento: String
 )
+
+data class UbicacionRechazadaResponse(
+    val nombre: String,
+    val direccion: String,
+    val motivo: String
+)

--- a/src/main/kotlin/com/crisordonez/registro/repository/UbicacionRepository.kt
+++ b/src/main/kotlin/com/crisordonez/registro/repository/UbicacionRepository.kt
@@ -12,7 +12,4 @@ interface UbicacionRepository: JpaRepository<UbicacionEntity, Long> {
     fun findByEstablecimiento(establecimiento: EstablecimientoEnum): List<UbicacionEntity>
 
     fun deleteByPublicId(publicId: UUID)
-
-    fun findByNombreAndDireccionAndEstablecimiento(nombre: String, direccion: String, establecimiento: EstablecimientoEnum): UbicacionEntity?
 }
-

--- a/src/main/kotlin/com/crisordonez/registro/service/UbicacionService.kt
+++ b/src/main/kotlin/com/crisordonez/registro/service/UbicacionService.kt
@@ -2,12 +2,14 @@ package com.crisordonez.registro.service
 
 import com.crisordonez.registro.model.entities.UbicacionEntity
 import com.crisordonez.registro.model.enums.EstablecimientoEnum
+import com.crisordonez.registro.model.responses.UbicacionRechazadaResponse
 import com.crisordonez.registro.repository.UbicacionRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.OffsetDateTime
 import java.util.UUID
+import kotlin.math.*
 
 @Service
 class UbicacionService(
@@ -25,52 +27,39 @@ class UbicacionService(
     }
 
     override fun crearUbicacion(ubicacion: UbicacionEntity): UbicacionEntity {
-        val existente = ubicacionRepository.findByNombreAndDireccionAndEstablecimiento(
-            ubicacion.nombre,
-            ubicacion.direccion,
-            ubicacion.establecimiento
-        )
-
-        return if (existente == null) {
-            ubicacionRepository.save(ubicacion)
-        } else {
-            // Si existe la misma combinación, actualiza campos básicos (sin cambiar establecimiento)
-            existente.telefono = ubicacion.telefono
-            existente.horario = ubicacion.horario
-            existente.sitioWeb = ubicacion.sitioWeb
-            existente.latitud = ubicacion.latitud
-            existente.longitud = ubicacion.longitud
-            existente.updatedAt = OffsetDateTime.now()
-
-            ubicacionRepository.save(existente)
+        if (existeUbicacionCercana(ubicacion.latitud, ubicacion.longitud, ubicacion.establecimiento)) {
+            throw IllegalArgumentException("Ya existe una ubicación cercana en ese punto.")
         }
+
+        return ubicacionRepository.save(ubicacion)
     }
 
-    override fun crearUbicaciones(ubicaciones: List<UbicacionEntity>): List<UbicacionEntity> {
-        val resultado = mutableListOf<UbicacionEntity>()
+    data class ResultadoCargarUbicaciones(
+        val creadas: List<UbicacionEntity>,
+        val rechazadas: List<UbicacionRechazadaResponse>
+    )
+
+
+    override fun crearUbicaciones(ubicaciones: List<UbicacionEntity>): ResultadoCargarUbicaciones {
+        val creadas = mutableListOf<UbicacionEntity>()
+        val rechazadas = mutableListOf<UbicacionRechazadaResponse>()
         log.info("Creando ubicaciones en lote, total: ${ubicaciones.size}")
         for (ubicacion in ubicaciones) {
-            val existente = ubicacionRepository.findByNombreAndDireccionAndEstablecimiento(
-                ubicacion.nombre,
-                ubicacion.direccion,
-                ubicacion.establecimiento
-            )
-            val ubicacionFinal = if (existente == null) {
-                ubicacionRepository.save(ubicacion)
+            if (existeUbicacionCercana(ubicacion.latitud, ubicacion.longitud, ubicacion.establecimiento)) {
+                rechazadas.add(
+                    UbicacionRechazadaResponse(
+                        nombre = ubicacion.nombre,
+                        direccion = ubicacion.direccion,
+                        motivo = "Ubicación cercana ya registrada"
+                    )
+                )
             } else {
-                existente.telefono = ubicacion.telefono
-                existente.horario = ubicacion.horario
-                existente.sitioWeb = ubicacion.sitioWeb
-                existente.latitud = ubicacion.latitud
-                existente.longitud = ubicacion.longitud
-                existente.updatedAt = OffsetDateTime.now()
-
-                ubicacionRepository.save(existente)
+                val guardada = ubicacionRepository.save(ubicacion)
+                creadas.add(guardada)
             }
-            resultado.add(ubicacionFinal)
         }
-        log.info("Ubicaciones creadas en lote correctamente, total: ${resultado.size}")
-        return resultado
+        log.info("Ubicaciones creadas: ${creadas.size}, rechazadas: ${rechazadas.size}")
+        return ResultadoCargarUbicaciones(creadas, rechazadas)
     }
 
     @Transactional
@@ -98,5 +87,35 @@ class UbicacionService(
         log.info("Eliminando ubicación con publicId: $publicId")
         ubicacionRepository.deleteByPublicId(publicId)
         log.info("Ubicación eliminada correctamente")
+    }
+
+    private fun calcularDistanciaMetros(
+        lat1: Double, lon1: Double,
+        lat2: Double, lon2: Double
+    ): Double {
+        val radioTierra = 6371000.0 // en metros
+
+        val dLat = Math.toRadians(lat2 - lat1)
+        val dLon = Math.toRadians(lon2 - lon1)
+
+        val a = sin(dLat / 2).pow(2.0) +
+                cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+                sin(dLon / 2).pow(2.0)
+
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+
+        return radioTierra * c
+    }
+
+    private fun existeUbicacionCercana(
+        lat: Double,
+        lon: Double,
+        establecimiento: EstablecimientoEnum,
+        umbralMetros: Double = 10.0
+    ): Boolean {
+        val ubicaciones = ubicacionRepository.findByEstablecimiento(establecimiento)
+        return ubicaciones.any {
+            calcularDistanciaMetros(lat, lon, it.latitud, it.longitud) < umbralMetros
+        }
     }
 }

--- a/src/main/kotlin/com/crisordonez/registro/service/UbicacionServiceInterface.kt
+++ b/src/main/kotlin/com/crisordonez/registro/service/UbicacionServiceInterface.kt
@@ -1,6 +1,7 @@
 package com.crisordonez.registro.service
 
 import com.crisordonez.registro.model.entities.UbicacionEntity
+import com.crisordonez.registro.service.UbicacionService.ResultadoCargarUbicaciones
 import com.crisordonez.registro.model.enums.EstablecimientoEnum
 import java.util.UUID
 
@@ -12,7 +13,7 @@ interface UbicacionServiceInterface {
 
     fun crearUbicacion(ubicacion: UbicacionEntity): UbicacionEntity
 
-    fun crearUbicaciones(ubicaciones: List<UbicacionEntity>): List<UbicacionEntity>
+    fun crearUbicaciones(ubicaciones: List<UbicacionEntity>): ResultadoCargarUbicaciones
 
     fun actualizarUbicacion(publicId: UUID, ubicacion: UbicacionEntity): UbicacionEntity?
 


### PR DESCRIPTION
Added proximity-based duplication check using the Haversine formula to prevent registering locations within 10 meters of each other.

Validation now respects the establishment type, allowing nearby points in different categories (e.g., CENTRO_SALUD vs CENTRO_PROTECCION).

Batch upload (/lote) now returns a structured response including:

- Successfully created locations.
- Rejected locations with explanation.

Standardized API error messages to enable frontend handling.